### PR TITLE
Validate sender domain before constructing contact email

### DIFF
--- a/src/actions/sendEmail.ts
+++ b/src/actions/sendEmail.ts
@@ -33,6 +33,10 @@ export const sendEmail = async (formData: FormData) => {
     return { error: 'Recipient email not configured' };
   }
 
+  if (!process.env.RESEND_EMAIL_DOMAIN) {
+    return { error: 'Sender domain not configured' };
+  }
+
   const fromEmail = `noreply@${process.env.RESEND_EMAIL_DOMAIN}`;
 
   try {


### PR DESCRIPTION
## Summary
- ensure `sendEmail` action verifies `RESEND_EMAIL_DOMAIN`
- construct `fromEmail` only after confirming all email environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8887e97c48329a1fa6ebb99ce54ce