### PR TITLE
fix: spacing in Imaginify project description

### DIFF
--- a/src/lib/data.tsx
+++ b/src/lib/data.tsx
@@ -62,7 +62,7 @@ export const projectsData = [
     description: (
       <>
         An online SaaS platform enabling users to edit photos using AI. It is possible to restore
-        images in poor quality, generative fill image surroundings,remove or recolor objects or
+        images in poor quality, generative fill image surroundings, remove or recolor objects or
         remove image background. Each edit costs one credit and credits can be purchased via Stripe
         payment gateway. Each user can view their edited images in their profile and all of the
         edits in homepage. Used for learning and based on design and resources provided by{' '}


### PR DESCRIPTION
## Summary
- fix Imaginify project description spacing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a888733e40832985579aae7d682d3c