### PR TITLE
Animate about text with scroll reveal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,7 +24,7 @@
 }
 
 @utility section-divider {
-  @apply bg-gray-300 my-24 h-1 rounded-full;
+  @apply bg-gray-300 my-16 h-1 rounded-full sm:my-24 lg:my-32;
 }
 
 @utility section-heading {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -88,7 +88,7 @@
 }
 
 @utility about-text {
-  @apply text-lg leading-relaxed sm:text-xl lg:text-2xl;
+  @apply text-xl tracking-wide leading-relaxed sm:text-2xl lg:text-3xl;
 }
 
 @utility collaboration-text {

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -23,7 +23,7 @@ const About = () => {
       id='about'>
       <SectionHeading>About me</SectionHeading>
       <TextRevealOnScroll
-        className='about-text space-y-8'
+        className='about-text space-y-8 sm:space-y-12 lg:space-y-16'
         paragraphs={[
           "I build interfaces that feel effortless to use and memorable to look at. Frontend development, for me, is the sweet spot where logical problem-solving meets creative expression — transforming ideas into smooth, intuitive, and visually engaging experiences.",
           "I focus on writing clean, well-structured code and crafting designs that are both functional and delightful to interact with. I enjoy working with modern tools and frameworks to deliver software that is robust, elegant, and built to last. Beyond writing code, I pay attention to the small details that make a big difference, from subtle animations to polished interaction flows.",

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -22,20 +22,10 @@ const About = () => {
       transition={{ delay: 0.25 }}
       id='about'>
       <SectionHeading>About me</SectionHeading>
-      <TextRevealOnScroll
-        className='about-text mb-3'
-        text="I build interfaces that feel effortless to use and memorable to look at. Frontend development, for me, is the sweet spot where logical problem-solving meets creative expression — transforming ideas into smooth, intuitive, and visually engaging experiences. I focus on writing clean, well-structured code and crafting designs that are both functional and delightful to interact with. I enjoy working with modern tools and frameworks to deliver software that is robust, elegant, and built to last. Beyond writing code, I pay attention to the small details that make a big difference, from subtle animations to polished interaction flows."
-      />
-
-      <TextRevealOnScroll
-        className='about-text mb-3'
-        text="I'm endlessly curious, always exploring new technologies, experimenting with UI animations, and refining interaction details that elevate the user experience. My goal isn't just to deliver features, but to craft software that people genuinely enjoy using."
-      />
-
-      <TextRevealOnScroll
-        className='about-text'
-        text="When I'm not coding, you'll find me hiking, reading, or tinkering with side projects—always learning, always building."
-      />
+        <TextRevealOnScroll
+          className='about-text'
+          text="I build interfaces that feel effortless to use and memorable to look at. Frontend development, for me, is the sweet spot where logical problem-solving meets creative expression — transforming ideas into smooth, intuitive, and visually engaging experiences. I focus on writing clean, well-structured code and crafting designs that are both functional and delightful to interact with. I enjoy working with modern tools and frameworks to deliver software that is robust, elegant, and built to last. Beyond writing code, I pay attention to the small details that make a big difference, from subtle animations to polished interaction flows. I'm endlessly curious, always exploring new technologies, experimenting with UI animations, and refining interaction details that elevate the user experience. My goal isn't just to deliver features, but to craft software that people genuinely enjoy using. When I'm not coding, you'll find me hiking, reading, or tinkering with side projects—always learning, always building."
+        />
     </motion.section>
   );
 };

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -22,10 +22,20 @@ const About = () => {
       transition={{ delay: 0.25 }}
       id='about'>
       <SectionHeading>About me</SectionHeading>
+      <div className='space-y-8'>
         <TextRevealOnScroll
           className='about-text'
-          text="I build interfaces that feel effortless to use and memorable to look at. Frontend development, for me, is the sweet spot where logical problem-solving meets creative expression — transforming ideas into smooth, intuitive, and visually engaging experiences. I focus on writing clean, well-structured code and crafting designs that are both functional and delightful to interact with. I enjoy working with modern tools and frameworks to deliver software that is robust, elegant, and built to last. Beyond writing code, I pay attention to the small details that make a big difference, from subtle animations to polished interaction flows. I'm endlessly curious, always exploring new technologies, experimenting with UI animations, and refining interaction details that elevate the user experience. My goal isn't just to deliver features, but to craft software that people genuinely enjoy using. When I'm not coding, you'll find me hiking, reading, or tinkering with side projects—always learning, always building."
+          text="I build interfaces that feel effortless to use and memorable to look at. Frontend development, for me, is the sweet spot where logical problem-solving meets creative expression — transforming ideas into smooth, intuitive, and visually engaging experiences."
         />
+        <TextRevealOnScroll
+          className='about-text'
+          text="I focus on writing clean, well-structured code and crafting designs that are both functional and delightful to interact with. I enjoy working with modern tools and frameworks to deliver software that is robust, elegant, and built to last. Beyond writing code, I pay attention to the small details that make a big difference, from subtle animations to polished interaction flows."
+        />
+        <TextRevealOnScroll
+          className='about-text'
+          text="I'm endlessly curious, always exploring new technologies, experimenting with UI animations, and refining interaction details that elevate the user experience. My goal isn't just to deliver features, but to craft software that people genuinely enjoy using. When I'm not coding, you'll find me hiking, reading, or tinkering with side projects—always learning, always building."
+        />
+      </div>
     </motion.section>
   );
 };

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -22,20 +22,14 @@ const About = () => {
       transition={{ delay: 0.25 }}
       id='about'>
       <SectionHeading>About me</SectionHeading>
-      <div className='space-y-8'>
-        <TextRevealOnScroll
-          className='about-text'
-          text="I build interfaces that feel effortless to use and memorable to look at. Frontend development, for me, is the sweet spot where logical problem-solving meets creative expression — transforming ideas into smooth, intuitive, and visually engaging experiences."
-        />
-        <TextRevealOnScroll
-          className='about-text'
-          text="I focus on writing clean, well-structured code and crafting designs that are both functional and delightful to interact with. I enjoy working with modern tools and frameworks to deliver software that is robust, elegant, and built to last. Beyond writing code, I pay attention to the small details that make a big difference, from subtle animations to polished interaction flows."
-        />
-        <TextRevealOnScroll
-          className='about-text'
-          text="I'm endlessly curious, always exploring new technologies, experimenting with UI animations, and refining interaction details that elevate the user experience. My goal isn't just to deliver features, but to craft software that people genuinely enjoy using. When I'm not coding, you'll find me hiking, reading, or tinkering with side projects—always learning, always building."
-        />
-      </div>
+      <TextRevealOnScroll
+        className='about-text space-y-8'
+        paragraphs={[
+          "I build interfaces that feel effortless to use and memorable to look at. Frontend development, for me, is the sweet spot where logical problem-solving meets creative expression — transforming ideas into smooth, intuitive, and visually engaging experiences.",
+          "I focus on writing clean, well-structured code and crafting designs that are both functional and delightful to interact with. I enjoy working with modern tools and frameworks to deliver software that is robust, elegant, and built to last. Beyond writing code, I pay attention to the small details that make a big difference, from subtle animations to polished interaction flows.",
+          "I'm endlessly curious, always exploring new technologies, experimenting with UI animations, and refining interaction details that elevate the user experience. My goal isn't just to deliver features, but to craft software that people genuinely enjoy using. When I'm not coding, you'll find me hiking, reading, or tinkering with side projects—always learning, always building.",
+        ]}
+      />
     </motion.section>
   );
 };

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import SectionHeading from '@/components/SectionHeading';
+import TextRevealOnScroll from '@/components/TextRevealOnScroll';
 import useSectionInView from '@/hooks/useSectionInView';
 import useIsMobile from '@/hooks/useIsMobile';
 
@@ -21,29 +22,20 @@ const About = () => {
       transition={{ delay: 0.25 }}
       id='about'>
       <SectionHeading>About me</SectionHeading>
-      <p className='about-text mb-3'>
-        I build interfaces that feel effortless to use and memorable to look at. Frontend
-        development, for me, is the sweet spot where logical problem-solving meets creative
-        expression — transforming ideas into smooth, intuitive, and visually engaging experiences. I
-        focus on writing <span className='font-medium'>clean, well-structured code</span> and
-        crafting designs that are both functional and delightful to interact with. I enjoy working
-        with <span className='font-medium'>modern tools and frameworks</span> to deliver software
-        that is robust, elegant, and built to last. Beyond writing code, I pay attention to the
-        small details that make a big difference, from subtle animations to polished interaction
-        flows.
-      </p>
+      <TextRevealOnScroll
+        className='about-text mb-3'
+        text="I build interfaces that feel effortless to use and memorable to look at. Frontend development, for me, is the sweet spot where logical problem-solving meets creative expression — transforming ideas into smooth, intuitive, and visually engaging experiences. I focus on writing clean, well-structured code and crafting designs that are both functional and delightful to interact with. I enjoy working with modern tools and frameworks to deliver software that is robust, elegant, and built to last. Beyond writing code, I pay attention to the small details that make a big difference, from subtle animations to polished interaction flows."
+      />
 
-      <p className='about-text mb-3'>
-        I&apos;m endlessly curious, always exploring new technologies, experimenting with UI
-        animations, and refining interaction details that elevate the user experience. My goal
-        isn&apos;t just to deliver features, but to craft software that people genuinely enjoy
-        using.
-      </p>
+      <TextRevealOnScroll
+        className='about-text mb-3'
+        text="I'm endlessly curious, always exploring new technologies, experimenting with UI animations, and refining interaction details that elevate the user experience. My goal isn't just to deliver features, but to craft software that people genuinely enjoy using."
+      />
 
-      <p className='about-text'>
-        When I&apos;m not coding, you&apos;ll find me hiking, reading, or tinkering with side
-        projects&mdash;always learning, always building.
-      </p>
+      <TextRevealOnScroll
+        className='about-text'
+        text="When I'm not coding, you'll find me hiking, reading, or tinkering with side projects—always learning, always building."
+      />
     </motion.section>
   );
 };

--- a/src/components/AnimatedWord.tsx
+++ b/src/components/AnimatedWord.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import type { MotionValue } from 'framer-motion';
+import { motion, useTransform } from 'framer-motion';
+
+export type AnimatedWordProps = {
+  word: string;
+  index: number;
+  totalWords: number;
+  scrollYProgress: MotionValue<number>;
+};
+
+const AnimatedWord = ({ word, index, totalWords, scrollYProgress }: AnimatedWordProps) => {
+  const start = index / totalWords;
+  const end = (index + 1) / totalWords;
+  const opacity = useTransform(scrollYProgress, [start, end], [0.2, 1]);
+
+  return (
+    <motion.span style={{ opacity }} className='inline-block'>
+      {word}
+      {index < totalWords - 1 && '\u00A0'}
+    </motion.span>
+  );
+};
+
+export default AnimatedWord;

--- a/src/components/AnimatedWord.tsx
+++ b/src/components/AnimatedWord.tsx
@@ -12,11 +12,11 @@ export type AnimatedWordProps = {
 
 const AnimatedWord = ({ word, index, totalWords, scrollYProgress }: AnimatedWordProps) => {
   const start = index / totalWords;
-  const end = (index + 1) / totalWords;
+  const end = (index + 0.3) / totalWords;
   const opacity = useTransform(scrollYProgress, [start, end], [0.2, 1]);
 
   return (
-    <motion.span style={{ opacity }} className='inline-block'>
+    <motion.span style={{ opacity }} className='inline-block text-white'>
       {word}
       {index < totalWords - 1 && '\u00A0'}
     </motion.span>

--- a/src/components/AnimatedWord.tsx
+++ b/src/components/AnimatedWord.tsx
@@ -5,20 +5,29 @@ import { motion, useTransform } from 'framer-motion';
 
 export type AnimatedWordProps = {
   word: string;
-  index: number;
-  totalWords: number;
+  groupIndex: number;
+  totalGroups: number;
+  isLast: boolean;
   scrollYProgress: MotionValue<number>;
 };
 
-const AnimatedWord = ({ word, index, totalWords, scrollYProgress }: AnimatedWordProps) => {
-  const start = index / totalWords;
-  const end = (index + 0.3) / totalWords;
+const AnimatedWord = ({
+  word,
+  groupIndex,
+  totalGroups,
+  isLast,
+  scrollYProgress,
+}: AnimatedWordProps) => {
+  const maxProgress = 0.6;
+  const step = maxProgress / totalGroups;
+  const start = groupIndex * step;
+  const end = start + step;
   const opacity = useTransform(scrollYProgress, [start, end], [0.2, 1]);
 
   return (
     <motion.span style={{ opacity }} className='inline-block text-white'>
       {word}
-      {index < totalWords - 1 && '\u00A0'}
+      {!isLast && '\u00A0'}
     </motion.span>
   );
 };

--- a/src/components/AnimatedWord.tsx
+++ b/src/components/AnimatedWord.tsx
@@ -18,7 +18,7 @@ const AnimatedWord = ({
   isLast,
   scrollYProgress,
 }: AnimatedWordProps) => {
-  const maxProgress = 0.6;
+  const maxProgress = 0.75;
   const step = maxProgress / totalGroups;
   const start = groupIndex * step;
   const end = start + step;

--- a/src/components/TextRevealOnScroll.tsx
+++ b/src/components/TextRevealOnScroll.tsx
@@ -17,21 +17,26 @@ const TextRevealOnScroll = ({ paragraphs, className }: TextRevealOnScrollProps) 
   });
 
   const allWords = paragraphs.flatMap((p) => p.split(' '));
+  const totalGroups = Math.ceil(allWords.length / 2);
   let wordOffset = 0;
 
   return (
     <div ref={ref} className={className}>
       {paragraphs.map((paragraph, pIndex) => {
         const words = paragraph.split(' ');
-        const content = words.map((word, index) => (
-          <AnimatedWord
-            key={`${word}-${wordOffset + index}`}
-            word={word}
-            index={wordOffset + index}
-            totalWords={allWords.length}
-            scrollYProgress={scrollYProgress}
-          />
-        ));
+        const content = words.map((word, index) => {
+          const globalIndex = wordOffset + index;
+          return (
+            <AnimatedWord
+              key={`${word}-${globalIndex}`}
+              word={word}
+              groupIndex={Math.floor(globalIndex / 2)}
+              totalGroups={totalGroups}
+              isLast={globalIndex === allWords.length - 1}
+              scrollYProgress={scrollYProgress}
+            />
+          );
+        });
         wordOffset += words.length;
         return <p key={pIndex}>{content}</p>;
       })}

--- a/src/components/TextRevealOnScroll.tsx
+++ b/src/components/TextRevealOnScroll.tsx
@@ -5,31 +5,37 @@ import { useRef } from 'react';
 import AnimatedWord from '@/components/AnimatedWord';
 
 type TextRevealOnScrollProps = {
-  text: string;
+  paragraphs: string[];
   className?: string;
 };
 
-const TextRevealOnScroll = ({ text, className }: TextRevealOnScrollProps) => {
-  const ref = useRef<HTMLParagraphElement>(null);
+const TextRevealOnScroll = ({ paragraphs, className }: TextRevealOnScrollProps) => {
+  const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: ref,
     offset: ['start end', 'end start'],
   });
 
-  const words = text.split(' ');
+  const allWords = paragraphs.flatMap((p) => p.split(' '));
+  let wordOffset = 0;
 
   return (
-    <p ref={ref} className={className}>
-      {words.map((word, index) => (
-        <AnimatedWord
-          key={`${word}-${index}`}
-          word={word}
-          index={index}
-          totalWords={words.length}
-          scrollYProgress={scrollYProgress}
-        />
-      ))}
-    </p>
+    <div ref={ref} className={className}>
+      {paragraphs.map((paragraph, pIndex) => {
+        const words = paragraph.split(' ');
+        const content = words.map((word, index) => (
+          <AnimatedWord
+            key={`${word}-${wordOffset + index}`}
+            word={word}
+            index={wordOffset + index}
+            totalWords={allWords.length}
+            scrollYProgress={scrollYProgress}
+          />
+        ));
+        wordOffset += words.length;
+        return <p key={pIndex}>{content}</p>;
+      })}
+    </div>
   );
 };
 

--- a/src/components/TextRevealOnScroll.tsx
+++ b/src/components/TextRevealOnScroll.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useScroll } from 'framer-motion';
+import { useRef } from 'react';
+import AnimatedWord from '@/components/AnimatedWord';
+
+type TextRevealOnScrollProps = {
+  text: string;
+  className?: string;
+};
+
+const TextRevealOnScroll = ({ text, className }: TextRevealOnScrollProps) => {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ['start end', 'end start'],
+  });
+
+  const words = text.split(' ');
+
+  return (
+    <p ref={ref} className={className}>
+      {words.map((word, index) => (
+        <AnimatedWord
+          key={`${word}-${index}`}
+          word={word}
+          index={index}
+          totalWords={words.length}
+          scrollYProgress={scrollYProgress}
+        />
+      ))}
+    </p>
+  );
+};
+
+export default TextRevealOnScroll;


### PR DESCRIPTION
## Summary
- animate About section text word-by-word on scroll
- add reusable TextRevealOnScroll component for scroll-driven opacity
- extract AnimatedWord into its own file to follow component guidelines

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8b11e48b88329b039d2adf8623c7a